### PR TITLE
Dockerfile updated to build jar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ENV JAVA_OPTS=$JAVA_OPTS
 ENV JDBC_URL=jdbc:postgresql://postgresql-class.cks98gmxels6.us-west-1.rds.amazonaws.com:5432/interview_tracker_db
 ENV JDBC_USERNAME=sep1909
 ENV JDBC_PASSWORD=interview123
+RUN mvn package
 ADD target/Interview-Service-0.0.1-SNAPSHOT.jar interview-service.jar
 EXPOSE 50222
 ENTRYPOINT exec java $JAVA_OPTS -jar interview-service.jar


### PR DESCRIPTION
In order to create a docker image from a dockerfile, a jar of the service is required, so I added the following line to make sure the latest jar created is  being used:

RUN mvn package // builds project jar

// to be sure the mvn is recognized as a CMD command, one may be required to update his system environment (MAVEN_HOME or M2_HOME https://www.tutorialspoint.com/maven/maven_environment_setup.htm )